### PR TITLE
feat: Add dotenv package

### DIFF
--- a/packages/@aurgy/server/package.json
+++ b/packages/@aurgy/server/package.json
@@ -30,6 +30,7 @@
     "@types/node-fetch": "2.5.12",
     "@typescript-eslint/eslint-plugin": "^5.49.0",
     "@typescript-eslint/parser": "^5.49.0",
+    "dotenv": "^16.0.3",
     "eslint": "^8.32.0",
     "eslint-plugin-import": "^2.22.1",
     "nodemon": "^2.0.15",

--- a/packages/@aurgy/server/www/index.ts
+++ b/packages/@aurgy/server/www/index.ts
@@ -2,6 +2,9 @@ import cors from 'cors';
 import express from 'express';
 import {logger} from '../utils';
 
+import * as dotenv from 'dotenv'
+dotenv.config()
+
 // ROUTES
 import { lobby_router } from './lobby';
 import { me_router } from './me';

--- a/packages/@aurgy/server/www/index.ts
+++ b/packages/@aurgy/server/www/index.ts
@@ -2,8 +2,8 @@ import cors from 'cors';
 import express from 'express';
 import {logger} from '../utils';
 
-import * as dotenv from 'dotenv'
-dotenv.config()
+import * as dotenv from 'dotenv';
+dotenv.config();
 
 // ROUTES
 import { lobby_router } from './lobby';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3845,6 +3845,11 @@ dot-prop@^6.0.1:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@^16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
+  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
+
 dotenv@~10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"


### PR DESCRIPTION
Add dotenv npm package so we can use a .env file for our environment variables instead of having to manually set the environment variables in the shell

To use dotenv:
- Make a .env file inside the `packages/@aurgy/server/` directory 
- Add the two variables to the .env file
```
GOOGLE_APPLICATION_CREDENTIALS="ur_path.json"
TOKEN_SECRET="the_token_secret"
```
- test that the project still builds and runs correctly