### PR TITLE
fix: Fix processing of Firestore collection.get() 

### DIFF
--- a/packages/@aurgy/server/lib/db-client.ts
+++ b/packages/@aurgy/server/lib/db-client.ts
@@ -1,3 +1,4 @@
+import { QueryDocumentSnapshot } from '@google-cloud/firestore';
 import {Firestore} from '@google-cloud/firestore';
 import { DbItem } from './db-item';
 
@@ -83,11 +84,16 @@ export class DbClient {
    *
    * @param collectionName the collection to query
    * @returns all the items in a collection
+   * the items are represent as json objects
    */
-  public async getCollectionItems(collectionName: string): Promise<any[]> {
+  public async getCollectionItems(collectionName: string): Promise<FirebaseFirestore.DocumentData[]> {
     const collection = await this.openCollection(collectionName);
     const docs = await collection.get();
-    return docs;
+    const data: FirebaseFirestore.DocumentData[] = [];
+    docs.forEach((doc: QueryDocumentSnapshot) => {
+      data.push(doc.data());
+    });
+    return data;
   }
 
   /**

--- a/packages/@aurgy/server/lib/db-client.ts
+++ b/packages/@aurgy/server/lib/db-client.ts
@@ -1,5 +1,4 @@
-import { QueryDocumentSnapshot } from '@google-cloud/firestore';
-import {Firestore} from '@google-cloud/firestore';
+import { Firestore, QueryDocumentSnapshot } from '@google-cloud/firestore';
 import { DbItem } from './db-item';
 
 /**

--- a/packages/@aurgy/server/lib/lobby.ts
+++ b/packages/@aurgy/server/lib/lobby.ts
@@ -84,8 +84,7 @@ export class Lobby extends DbItem implements ILobby {
     const client = await getClient();
     const docs = await client.getCollectionItems(COLLECTION.LOBBIES);
     return await Promise.all(docs.map(doc => {
-      const content = doc.getContent();
-      return new Lobby(content.id, content as DatabaseEntry, content.key);
+      return new Lobby(doc.id, doc as DatabaseEntry, doc.key);
     }));
   }
 

--- a/packages/@aurgy/server/lib/song.ts
+++ b/packages/@aurgy/server/lib/song.ts
@@ -61,8 +61,7 @@ export class Song extends DbItem implements ISong {
     const client = await getClient();
     const docs = await client.getCollectionItems(COLLECTION.SONGS);
     return await Promise.all(docs.map(doc => {
-      const content = doc.getContent();
-      return new Song(content.id, content as DatabaseEntry, content.key);
+      return new Song(doc.id, doc as DatabaseEntry, doc.key);
     }));
   }
 


### PR DESCRIPTION
There was a bug in db.client and the Song.all() and Lobby.all() function
It was using map to process the result of `openCollection().get()`
Instead the correct way to use it is with forEach

This is a guide on getting all the documents from a Firestore collection
https://firebase.google.com/docs/firestore/query-data/get-data#get_multiple_documents_from_a_collection

To test, just make sure Lobby.all() and Song.all() can run