### PR TITLE
chore: Add firestore private key to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ data/
 # Never commit environment variables
 .env
 credentials.json
+
+# Never commit Firestore private key
+song-spotter*.json


### PR DESCRIPTION
Assuming the private key file isn't renamed, the gitignore should match the private key file